### PR TITLE
:zap: [tardis_client] Faster datetime processing

### DIFF
--- a/tardis_client/tardis_client.py
+++ b/tardis_client/tardis_client.py
@@ -119,9 +119,7 @@ class TardisClient:
                         # since python datetime has microsecond precision and provided timestamp has 100ns precision
                         # we ignore last two characters of timestmap provided by the API (last character is Z)
                         # so we can decode it as python datetime
-                        timestamp = datetime.strptime(
-                            line[0 : DATE_MESSAGE_SPLIT_INDEX - 2].decode("utf-8"), "%Y-%m-%dT%H:%M:%S.%f"
-                        )
+                        timestamp = datetime.fromisoformat(line[0 : DATE_MESSAGE_SPLIT_INDEX - 2].decode("utf-8"))
 
                         yield Response(timestamp, json.loads(line[DATE_MESSAGE_SPLIT_INDEX + 1 :]))
                     else:


### PR DESCRIPTION
Problem:
- `strptime()` is slow - for standard formats it is much faster to
  process data with a custom processing function.

Solution:
- Since the data is already in ISO8601 format, use `fromisoformat()` to
  parse the data. `ciso8601` didn't show a significant improvement over
  this approach in my testing.